### PR TITLE
Fix CLI crashes, hardcoded version, and mixed-style corners

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# ascii-align Development Rules
+
+## TDD Required
+
+All bug fixes and features MUST follow test-driven development:
+1. Write failing test(s) first that demonstrate the bug or specify the feature
+2. Run tests to confirm they fail
+3. Implement the fix/feature
+4. Run tests to confirm they pass
+5. Never skip this workflow
+
+## Git Workflow
+
+- Never push directly to `main` — always use feature branches and PRs
+- Branch naming: `fix/<issue-description>` for bugs, `feat/<description>` for features
+- Reference GitHub issues in commits with `Fixes #N` or `Closes #N`
+- CI must pass before merging
+
+## No AI Attribution
+
+- Never include "Co-Authored-By", "Claude", "anthropic", or "Generated with" in commits, PRs, or issues
+- The `.claude/settings.json` disables attribution and a hook blocks it as a safety net
+
+## Code Style
+
+- TypeScript strict mode
+- ESM modules (`.js` extensions in imports)
+- Tests use Vitest
+- Keep the CLI version in sync with package.json (read dynamically, don't hardcode)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ascii-align",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Fix misaligned ASCII boxes and tables — perfect for AI-generated diagrams",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,25 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { program } from 'commander';
 import { fixAsciiAlign, checkAlignment } from './fix.js';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
+
+/** Read a file with a user-friendly error on failure */
+function readFile(file: string): string {
+  if (!existsSync(file)) {
+    console.error(`Error: File not found: ${file}`);
+    process.exit(1);
+  }
+  return readFileSync(file, 'utf-8');
+}
 
 program
   .name('ascii-align')
   .description('Fix misaligned ASCII boxes and tables — perfect for AI-generated diagrams')
-  .version('1.0.0');
+  .version(pkg.version);
 
 // Default command: read from stdin
 program
@@ -16,7 +29,7 @@ program
   .action((file: string | undefined, opts: { stdout?: boolean }) => {
     let input: string;
     if (file) {
-      input = readFileSync(file, 'utf-8');
+      input = readFile(file);
     } else {
       // Read from stdin
       input = readFileSync(0, 'utf-8');
@@ -41,7 +54,7 @@ program
   .command('check <file>')
   .description('Check alignment (exit code 1 if misaligned)')
   .action((file: string) => {
-    const input = readFileSync(file, 'utf-8');
+    const input = readFile(file);
     const result = checkAlignment(input);
     if (result.aligned) {
       console.log('All ASCII structures are properly aligned.');

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -8,6 +8,41 @@ function getBoxChars(style: BoxStyle): BoxChars {
   return BOX_CHARS[style];
 }
 
+// Sets for classifying corner/tee characters by position
+const TOP_LEFT_CHARS = new Set(['+', '┌', '┏', '╔']);
+const TOP_RIGHT_CHARS = new Set(['+', '┐', '┓', '╗']);
+const BOTTOM_LEFT_CHARS = new Set(['+', '└', '┗', '╚']);
+const BOTTOM_RIGHT_CHARS = new Set(['+', '┘', '┛', '╝']);
+const TEE_LEFT_CHARS = new Set(['+', '├', '┣', '╠']);
+const TEE_RIGHT_CHARS = new Set(['+', '┤', '┫', '╣']);
+const TEE_DOWN_CHARS = new Set(['+', '┬', '┳', '╦']);
+const TEE_UP_CHARS = new Set(['+', '┴', '┻', '╩']);
+const CROSS_CHARS = new Set(['+', '┼', '╋', '╬']);
+
+/**
+ * Map a corner/tee character to the correct character for the detected style.
+ * Uses position in the region (top/bottom/mid) to disambiguate '+' which
+ * maps to all corners in ASCII style.
+ */
+function mapCornerToStyle(ch: string, chars: BoxChars, side: 'left' | 'right', position: 'top' | 'bottom' | 'mid'): string {
+  // For non-ASCII chars, classify by character identity
+  if (TOP_LEFT_CHARS.has(ch) && !BOTTOM_LEFT_CHARS.has(ch) && side === 'left') return chars.topLeft;
+  if (TOP_RIGHT_CHARS.has(ch) && !BOTTOM_RIGHT_CHARS.has(ch) && side === 'right') return chars.topRight;
+  if (BOTTOM_LEFT_CHARS.has(ch) && !TOP_LEFT_CHARS.has(ch) && side === 'left') return chars.bottomLeft;
+  if (BOTTOM_RIGHT_CHARS.has(ch) && !TOP_RIGHT_CHARS.has(ch) && side === 'right') return chars.bottomRight;
+  if (TEE_LEFT_CHARS.has(ch) && ch !== '+' && side === 'left') return chars.teeLeft;
+  if (TEE_RIGHT_CHARS.has(ch) && ch !== '+' && side === 'right') return chars.teeRight;
+  if (TEE_DOWN_CHARS.has(ch) && ch !== '+') return chars.teeDown;
+  if (TEE_UP_CHARS.has(ch) && ch !== '+') return chars.teeUp;
+  if (CROSS_CHARS.has(ch) && ch !== '+') return chars.cross;
+
+  // For '+' (ASCII) or ambiguous chars, use positional info
+  if (position === 'top') return side === 'left' ? chars.topLeft : chars.topRight;
+  if (position === 'bottom') return side === 'left' ? chars.bottomLeft : chars.bottomRight;
+  // Mid-border: use tee chars
+  return side === 'left' ? chars.teeLeft : chars.teeRight;
+}
+
 /** Extract the leading whitespace (indentation) from a line */
 function getIndent(line: string): string {
   const match = line.match(/^(\s*)/);
@@ -43,16 +78,22 @@ function fixBox(lines: string[], region: Region): string[] {
 
   // Rebuild each line
   const result: string[] = [];
+  let borderIndex = 0;
+  const totalBorders = regionLines.filter(l => isBorderLine(l)).length;
   for (const line of regionLines) {
     if (isBorderLine(line)) {
       const trimmed = line.trim();
-      // Detect which corners/tees are present
       const firstChar = trimmed[0];
       const lastChar = trimmed[trimmed.length - 1];
 
-      // Determine the left and right characters to use
-      let left = firstChar;
-      let right = lastChar;
+      // Determine position: first border = top, last = bottom, others = mid
+      const position: 'top' | 'bottom' | 'mid' =
+        borderIndex === 0 ? 'top' : borderIndex === totalBorders - 1 ? 'bottom' : 'mid';
+      borderIndex++;
+
+      // Map corner/tee characters to the detected style to handle mixed-style boxes
+      const left = mapCornerToStyle(firstChar, chars, 'left', position);
+      const right = mapCornerToStyle(lastChar, chars, 'right', position);
 
       // Build the border: left + horizontal fill + right
       result.push(indent + left + chars.horizontal.repeat(maxContentWidth) + right);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cli = join(__dirname, '..', 'dist', 'cli.js');
+
+function run(args: string[], input?: string): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync('node', [cli, ...args], {
+      encoding: 'utf-8',
+      input,
+      timeout: 10000,
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? '',
+      exitCode: err.status ?? 1,
+    };
+  }
+}
+
+describe('CLI', () => {
+  it('prints a user-friendly error for non-existent file on check', () => {
+    // Issue #5: should not crash with raw stack trace
+    const result = run(['check', 'nonexistent.txt']);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).not.toContain('ENOENT');
+    expect(result.stderr).not.toContain('at ');
+    expect(result.stderr.toLowerCase()).toContain('not found');
+  });
+
+  it('prints a user-friendly error for non-existent file on fix', () => {
+    const result = run(['fix', 'nonexistent.txt']);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).not.toContain('ENOENT');
+    expect(result.stderr).not.toContain('at ');
+    expect(result.stderr.toLowerCase()).toContain('not found');
+  });
+
+  it('reports correct version matching package.json', () => {
+    // Issue #6: version should not be hardcoded
+    const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+    const result = run(['--version']);
+    expect(result.stdout.trim()).toBe(pkg.version);
+  });
+});

--- a/test/fix.test.ts
+++ b/test/fix.test.ts
@@ -137,6 +137,35 @@ describe('fixAsciiAlign', () => {
     expect(result).toContain('Cat');
     expect(result).toContain('Eagle');
   });
+
+  it('normalizes mixed-style box to use consistent characters (#7)', () => {
+    // ASCII top border with Unicode bottom border
+    // Detected as ASCII, so bottom corners should become + not └┘
+    const input = '+------+\n| test |\n└──┘';
+    const result = fixAsciiAlign(input);
+    const lines = result.split('\n');
+    // Bottom border corners should match detected style (ASCII: +)
+    expect(lines[2][0]).toBe('+');
+    expect(lines[2][lines[2].length - 1]).toBe('+');
+    // Bottom border fill should be ASCII dashes
+    expect(lines[2]).not.toContain('─');
+    // All borders should be same width
+    expect(lines[0].length).toBe(lines[2].length);
+  });
+
+  it('normalizes ASCII bottom in Unicode box to matching style (#7)', () => {
+    // Unicode top with ASCII bottom
+    // Detected as light, so bottom corners should become └┘ not +
+    const input = '┌──────┐\n│ test │\n+--+';
+    const result = fixAsciiAlign(input);
+    const lines = result.split('\n');
+    // Bottom border corners should match detected style (light: └ ┘)
+    expect(lines[2][0]).toBe('└');
+    expect(lines[2][lines[2].length - 1]).toBe('┘');
+    // Bottom border fill should be Unicode ─
+    expect(lines[2]).not.toContain('-');
+    expect(lines[0].length).toBe(lines[2].length);
+  });
 });
 
 describe('checkAlignment', () => {


### PR DESCRIPTION
## What

Three bug fixes found during exploratory testing, all developed with TDD.

## Why

Fixes #5, #6, #7

## Changes

**CLI error handling (#5):**
- Added `readFile()` helper with `existsSync` check
- Shows `Error: File not found: <path>` instead of raw ENOENT stack trace

**Dynamic version (#6):**
- CLI version now read from `package.json` via `createRequire`
- Will stay in sync across releases

**Mixed-style corner normalization (#7):**
- `fixBox()` now maps corner/tee characters to the detected style
- Uses border position (top/bottom/mid) to disambiguate ASCII `+`
- e.g., `└──┘` in an ASCII-detected box becomes `+------+`

**Other:**
- Added `CLAUDE.md` with TDD and workflow rules
- Added `test/cli.test.ts` (3 tests)
- Added 2 mixed-corner tests to `test/fix.test.ts`
- Version bump to 1.0.2

## Testing

- [x] `npm test` passes (44 tests)
- [x] `npm run check` passes
- [x] All tests written before implementation (TDD)