### PR TITLE
Fix tab characters treated as width 1 in visualWidth

### DIFF
--- a/src/measure.ts
+++ b/src/measure.ts
@@ -1,11 +1,30 @@
 import stringWidth from 'string-width';
 
 /**
+ * Replace tab characters with spaces aligned to tab stops.
+ */
+export function expandTabs(str: string, tabSize = 8): string {
+  let result = '';
+  let col = 0;
+  for (const ch of str) {
+    if (ch === '\t') {
+      const spaces = tabSize - (col % tabSize);
+      result += ' '.repeat(spaces);
+      col += spaces;
+    } else {
+      result += ch;
+      col += stringWidth(ch);
+    }
+  }
+  return result;
+}
+
+/**
  * Get the visual display width of a string.
- * Handles CJK characters (width 2), emoji, ANSI escape codes, etc.
+ * Handles CJK characters (width 2), emoji, ANSI escape codes, tabs, etc.
  */
 export function visualWidth(str: string): number {
-  return stringWidth(str);
+  return stringWidth(expandTabs(str));
 }
 
 /**

--- a/test/measure.test.ts
+++ b/test/measure.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { visualWidth, expandTabs } from '../src/measure.js';
+
+describe('expandTabs', () => {
+  it('expands a single tab to 8 spaces', () => {
+    expect(expandTabs('\t')).toBe('        ');
+  });
+
+  it('expands tab after characters to next tab stop', () => {
+    expect(expandTabs('ab\t')).toBe('ab      ');
+  });
+
+  it('expands two tabs to 16 columns', () => {
+    expect(expandTabs('\t\t')).toBe('                ');
+  });
+
+  it('expands tab between characters correctly', () => {
+    // a=1 col, tab fills to col 8, b at col 8
+    expect(expandTabs('a\tb')).toBe('a       b');
+  });
+});
+
+describe('visualWidth with tabs', () => {
+  it('counts a single tab as 8 columns', () => {
+    expect(visualWidth('\t')).toBe(8);
+  });
+
+  it('counts tab after characters to next tab stop', () => {
+    expect(visualWidth('ab\t')).toBe(8);
+  });
+
+  it('counts two tabs as 16 columns', () => {
+    expect(visualWidth('\t\t')).toBe(16);
+  });
+
+  it('counts tab between characters correctly', () => {
+    expect(visualWidth('a\tb')).toBe(9);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `expandTabs()` helper in `src/measure.ts` that replaces tab characters with spaces to the next tab stop (default 8)
- Updates `visualWidth()` to expand tabs before measuring width
- Adds 8 new tests in `test/measure.test.ts` covering tab expansion and visual width with tabs

## Test plan
- [x] New tests: `visualWidth('\t')` → 8, `visualWidth('ab\t')` → 8, `visualWidth('\t\t')` → 16
- [x] All existing tests pass
- [x] TypeScript build succeeds

Fixes #12