### PR TITLE
Fix nested lateral boxes with different heights (#21)

### DIFF
--- a/src/fix.ts
+++ b/src/fix.ts
@@ -279,8 +279,8 @@ function fixLateralBoxGroup(lines: string[], lateralRegions: Region[], depth: nu
 
   // Sort left-to-right by startCol
   const sorted = [...lateralRegions].sort((a, b) => (a.startCol ?? 0) - (b.startCol ?? 0));
-  const startLine = sorted[0].startLine;
-  const endLine = sorted[0].endLine;
+  const startLine = Math.min(...sorted.map(r => r.startLine));
+  const endLine = Math.max(...sorted.map(r => r.endLine));
 
   // Save original lines for gap measurement
   const origLines: string[] = [];
@@ -309,7 +309,9 @@ function fixLateralBoxGroup(lines: string[], lateralRegions: Region[], depth: nu
     const gapsForBox: number[] = [];
     for (let lineOffset = 0; lineOffset <= endLine - startLine; lineOffset++) {
       const origLine = origLines[lineOffset];
-      const thisBoxEnd = fixedBoxes[boxIdx].lineEnds[lineOffset];
+      const thisBoxEnd = fixedBoxes[boxIdx].lineEnds[lineOffset]
+        ?? fixedBoxes[boxIdx].lineEnds[fixedBoxes[boxIdx].lineEnds.length - 1]
+        ?? 0;
 
       // Measure gap: spaces between this box's end and next non-space char in original line
       let gapWidth = 0;
@@ -334,21 +336,33 @@ function fixLateralBoxGroup(lines: string[], lateralRegions: Region[], depth: nu
 
     let result = indent;
     for (let boxIdx = 0; boxIdx < fixedBoxes.length; boxIdx++) {
-      result += fixedBoxes[boxIdx].fixedSub[lineOffset];
+      const sub = fixedBoxes[boxIdx].fixedSub[lineOffset];
+      if (sub !== undefined) {
+        result += sub;
+      } else {
+        // Box ended above this line — fill with spaces matching its width
+        const boxWidth = fixedBoxes[boxIdx].fixedSub[0]?.length ?? 0;
+        result += ' '.repeat(boxWidth);
+      }
       if (boxIdx < fixedBoxes.length - 1) {
-        result += ' '.repeat(gaps[boxIdx][lineOffset]);
+        const gap = gaps[boxIdx]?.[lineOffset] ?? gaps[boxIdx]?.[0] ?? 1;
+        result += ' '.repeat(gap);
       }
     }
 
     // Append any trailing content after the last box in the original line
-    const lastBoxEnd = fixedBoxes[fixedBoxes.length - 1].lineEnds[lineOffset];
+    const lastBoxEnd = fixedBoxes[fixedBoxes.length - 1].lineEnds[lineOffset]
+      ?? fixedBoxes[fixedBoxes.length - 1].lineEnds[fixedBoxes[fixedBoxes.length - 1].lineEnds.length - 1]
+      ?? 0;
     const trailing = origLine.substring(lastBoxEnd + 1);
     const trimmedTrailing = trailing.trimStart();
     if (trimmedTrailing.length > 0) {
       result += trailing;
     }
 
-    lines[lineIdx] = result;
+    // Trim trailing whitespace to prevent space accumulation on lines
+    // where shorter boxes have ended and been filled with spaces
+    lines[lineIdx] = result.trimEnd();
   }
 }
 

--- a/test/fix.test.ts
+++ b/test/fix.test.ts
@@ -369,3 +369,50 @@ describe('checkAlignment', () => {
     expect(result.aligned).toBe(true);
   });
 });
+
+describe('nested lateral boxes with different heights (#21)', () => {
+  it('should not produce undefined when left box is taller than right box', () => {
+    const input = [
+      '+------+ +------+',
+      '| A    | | B    |',
+      '| a2   | | b2   |',
+      '| a3   | +------+',
+      '+------+',
+    ].join('\n');
+    const result = fixAsciiAlign(input);
+    expect(result).not.toContain('undefined');
+    expect(fixAsciiAlign(result)).toBe(result); // idempotent
+  });
+
+  it('should not produce undefined when right box is taller than left box', () => {
+    const input = [
+      '+------+ +------+',
+      '| A    | | B    |',
+      '| a2   | | b2   |',
+      '+------+ | b3   |',
+      '         +------+',
+    ].join('\n');
+    const result = fixAsciiAlign(input);
+    expect(result).not.toContain('undefined');
+    expect(fixAsciiAlign(result)).toBe(result); // idempotent
+  });
+
+  it('should handle k8s-style nested lateral boxes with different heights', () => {
+    const input = [
+      '+--------------------------------------+',
+      '| Cluster                              |',
+      '| +----------------+ +----------------+|',
+      '| | Control Plane  | | Worker Node    ||',
+      '| | +------------+ | | +------------+ ||',
+      '| | | apiserver  | | | | kubelet    | ||',
+      '| | +------------+ | | +------------+ ||',
+      '| +----------------+ | +----+ +----+  ||',
+      '|                    | | P1 | | P2 |  ||',
+      '|                    | +----+ +----+  ||',
+      '|                    +----------------+|',
+      '+--------------------------------------+',
+    ].join('\n');
+    const result = fixAsciiAlign(input);
+    expect(result).not.toContain('undefined');
+  });
+});


### PR DESCRIPTION
## Summary

- `fixLateralBoxGroup` assumed all lateral boxes in a group share the same `endLine`, causing literal `"undefined"` strings and broken borders when boxes have different heights (e.g., a Kubernetes architecture diagram with Control Plane and Worker Node boxes side-by-side)
- Compute correct line range using `Math.min`/`Math.max` across all regions instead of only the first box
- Guard all array accesses (`fixedSub`, `lineEnds`, `gaps`) to handle lines beyond a shorter box's range, filling with spaces of matching width
- Trim trailing whitespace on reassembled lines to ensure idempotency

## Test plan

- [x] Added test: left box taller than right box — no `undefined`, idempotent
- [x] Added test: right box taller than left box — no `undefined`, idempotent
- [x] Added test: k8s-style nested lateral boxes with different heights
- [x] All 75 existing + new tests pass
- [x] TypeScript compiles clean
- [x] CLI test on `tmp-k8s-diagram.txt` produces no `undefined` output

Fixes #21