### PR TITLE
Fix lateral box gap collapse on nested inner-box border rows

### DIFF
--- a/src/fix.ts
+++ b/src/fix.ts
@@ -245,6 +245,16 @@ function extractLateralBox(
     for (const seg of segments) {
       if (Math.abs(seg.start - refStart) <= tolerance &&
           Math.abs(seg.end - refEnd) <= tolerance) {
+        // Check if there's also a vertical bar near refEnd — if so,
+        // this is an inner border row (e.g. "| +---+ |"), not the box's own border.
+        const vertEnd = findVerticalNear(line, refEnd, tolerance);
+        if (vertEnd >= 0 && vertEnd !== seg.end) {
+          const vertStart = findVerticalNear(line, refStart, tolerance);
+          if (vertStart >= 0) actualStart = Math.min(actualStart, vertStart);
+          lineEnd = vertEnd;
+          foundBorder = true;
+          break;
+        }
         actualStart = Math.min(actualStart, seg.start);
         lineEnd = seg.end;
         foundBorder = true;

--- a/test/fix.test.ts
+++ b/test/fix.test.ts
@@ -415,4 +415,42 @@ describe('nested lateral boxes with different heights (#21)', () => {
     const result = fixAsciiAlign(input);
     expect(result).not.toContain('undefined');
   });
+
+  describe('lateral box gap on inner border rows (#23)', () => {
+    it('should preserve gap on rows with nested inner box borders', () => {
+      const input = [
+        '+-------------+ +-------------+',
+        '| Box A       | | Box B       |',
+        '| +---------+ | | +---------+ |',
+        '| | inner   | | | | inner   | |',
+        '| +---------+ | | +---------+ |',
+        '+-------------+ +-------------+',
+      ].join('\n');
+      const result = fixAsciiAlign(input);
+      // Output should preserve the input (already well-aligned)
+      expect(result).toBe(input);
+      // Idempotent
+      expect(fixAsciiAlign(result)).toBe(result);
+    });
+
+    it('should preserve 3-space gap with nested boxes', () => {
+      const input = [
+        '+---------------------------+   +-----------------------------------------------+',
+        '| Control Plane             |   | Worker Node 1                                 |',
+        '| +-----------------------+ |   | +-------------------------------------------+ |',
+        '| | kube-apiserver        | |   | | kubelet                                   | |',
+        '| +-----------------------+ |   | +-------------------------------------------+ |',
+        '+---------------------------+   +-----------------------------------------------+',
+      ].join('\n');
+      const result = fixAsciiAlign(input);
+      expect(result).not.toContain('undefined');
+      // Every line should have the 3-space gap preserved
+      const lines = result.split('\n');
+      for (const line of lines) {
+        // Between the two lateral boxes there should be 3 spaces
+        expect(line).toMatch(/[|+]\s{3}[|+]/);
+      }
+      expect(fixAsciiAlign(result)).toBe(result);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes gap collapse between lateral boxes on rows where nested inner boxes have horizontal borders (`+---+`)
- `extractLateralBox` was matching inner border segments as the outer box boundary, causing inconsistent gap measurement across rows
- Now detects inner border rows by checking for outer `|` near the reference position and uses those instead

## Test plan

- [x] Added test for 1-space gap preservation with nested inner boxes
- [x] Added test for 3-space gap preservation with nested inner boxes
- [x] Both tests verify idempotency
- [x] All 77 tests pass
- [x] TypeScript builds clean

Fixes #23