### PR TITLE
Fix lateral box bottom border erased when box ends before taller sibling

### DIFF
--- a/src/detect.ts
+++ b/src/detect.ts
@@ -181,6 +181,24 @@ function detectLateralBox(
           j = k;
           continue;
         }
+        // When two consecutive border lines are found (no content between them),
+        // check if the current border is an inner/nested border and the next line
+        // is a better match for the outer box's bottom border. This prevents
+        // treating an inner box's closing border as the outer box's bottom border.
+        if (!moreContent && k < lines.length) {
+          const nextBorderSeg = findBorderSegmentNear(lines[k], start, end, borderTolerance);
+          if (nextBorderSeg) {
+            // Compare which border better matches the box boundaries:
+            // the inner border (borderSeg at j) is typically offset from start/end,
+            // while the outer bottom border matches start/end more closely.
+            const jDist = Math.abs(borderSeg.start - start) + Math.abs(borderSeg.end - end);
+            const kDist = Math.abs(nextBorderSeg.start - start) + Math.abs(nextBorderSeg.end - end);
+            if (kDist < jDist) {
+              // The next border is a better match — current border is an inner border
+              return k;
+            }
+          }
+        }
         // Bottom border found
         return j;
       }

--- a/src/fix.ts
+++ b/src/fix.ts
@@ -247,13 +247,19 @@ function extractLateralBox(
           Math.abs(seg.end - refEnd) <= tolerance) {
         // Check if there's also a vertical bar near refEnd — if so,
         // this is an inner border row (e.g. "| +---+ |"), not the box's own border.
-        const vertEnd = findVerticalNear(line, refEnd, tolerance);
-        if (vertEnd >= 0 && vertEnd !== seg.end) {
-          const vertStart = findVerticalNear(line, refStart, tolerance);
-          if (vertStart >= 0) actualStart = Math.min(actualStart, vertStart);
-          lineEnd = vertEnd;
-          foundBorder = true;
-          break;
+        // Only treat as inner border if the border segment is strictly inside
+        // the box boundaries (start > refStart or end < refEnd), indicating it's
+        // a nested inner box border rather than the box's own top/bottom border.
+        const isInnerBorder = seg.start > refStart || seg.end < refEnd;
+        if (isInnerBorder) {
+          const vertEnd = findVerticalNear(line, refEnd, tolerance);
+          if (vertEnd >= 0 && vertEnd !== seg.end) {
+            const vertStart = findVerticalNear(line, refStart, tolerance);
+            if (vertStart >= 0) actualStart = Math.min(actualStart, vertStart);
+            lineEnd = vertEnd;
+            foundBorder = true;
+            break;
+          }
         }
         actualStart = Math.min(actualStart, seg.start);
         lineEnd = seg.end;

--- a/test/fix.test.ts
+++ b/test/fix.test.ts
@@ -453,4 +453,54 @@ describe('nested lateral boxes with different heights (#21)', () => {
       expect(fixAsciiAlign(result)).toBe(result);
     });
   });
+
+  describe('lateral box bottom border erased when box ends before taller sibling (#24)', () => {
+    it('should preserve shorter box bottom border when taller sibling continues', () => {
+      const input = [
+        '+-----------------------------------------------------------------------------------+',
+        '| Cluster                                                                           |',
+        '|                                                                                   |',
+        '| +---------------------------+   +-----------------------------------------------+ |',
+        '| | Control Plane             |   | Worker Node 1                                 | |',
+        '| |                           |   |                                               | |',
+        '| | +-----------------------+ |   | +-------------------------------------------+ | |',
+        '| | | kube-apiserver        | |   | | kubelet                                   | | |',
+        '| | | (REST API gateway)    | |   | | (node agent)                              | | |',
+        '| | +-----------------------+ |   | +-------------------------------------------+ | |',
+        '| +---------------------------+   |                                               | |',
+        '|                                 | +-------------------------------------------+ | |',
+        '|                                 | | Container Runtime                          | | |',
+        '|                                 | +-------------------------------------------+ | |',
+        '|                                 +-----------------------------------------------+ |',
+        '+-----------------------------------------------------------------------------------+',
+      ].join('\n');
+      const result = fixAsciiAlign(input);
+      // The Control Plane bottom border must be preserved on line 11 (0-indexed line 10)
+      const lines = result.split('\n');
+      expect(lines[10]).toContain('+---------------------------+');
+      // Should be idempotent
+      expect(fixAsciiAlign(result)).toBe(result);
+    });
+
+    it('should preserve shorter box bottom border in simple lateral case', () => {
+      const input = [
+        '+---------------------------+   +-----------------------------------------------+',
+        '| Control Plane             |   | Worker Node 1                                 |',
+        '| +-----------------------+ |   | +-------------------------------------------+ |',
+        '| | kube-apiserver        | |   | | kubelet                                   | |',
+        '| +-----------------------+ |   | +-------------------------------------------+ |',
+        '+---------------------------+   |                                               |',
+        '                                | +-------------------------------------------+ |',
+        '                                | | Container Runtime                          | |',
+        '                                | +-------------------------------------------+ |',
+        '                                +-----------------------------------------------+',
+      ].join('\n');
+      const result = fixAsciiAlign(input);
+      // The Control Plane bottom border on line 5 (0-indexed) must be preserved
+      const lines = result.split('\n');
+      expect(lines[5]).toContain('+---------------------------+');
+      // Should be idempotent
+      expect(fixAsciiAlign(result)).toBe(result);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes `detectLateralBox` returning inner border line as box bottom when two consecutive border lines exist, cutting the region short
- Fixes `extractLateralBox` incorrectly applying inner-border heuristics on the box's own bottom border line
- Adds 2 tests reproducing the bug (nested and simple lateral cases)

Fixes #24

## Test plan

- [x] New test: nested lateral boxes where shorter box (Control Plane) ends before taller sibling (Worker Node) — bottom border preserved
- [x] New test: simple lateral boxes with different heights — bottom border preserved
- [x] All existing tests pass